### PR TITLE
move dependencies over

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 
-	"github.com/labstack/gommon/color"
+	"github.com/kyani-inc/gommon/color"
 )
 
 type (


### PR DESCRIPTION
Change dependency over, so we're using the older gommon package. And there's no chance of bugs being introduced